### PR TITLE
Adjust heading colors for dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,6 +207,11 @@ h2 {
   color: var(--secondary);
 }
 
+body.dark h2,
+body.dark .card h3 {
+  color: var(--accent);
+}
+
 a.button {
   display: inline-block;
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- improve readability in dark theme by changing h2 and card heading colors to use the accent color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68731831fbc0832a8018aaeb39ce547c