### PR TITLE
Modernize font stack

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <meta name="author" content="Jon Tolden">
   <link rel="icon" type="image/png" href="favicon.png">
   <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ html {
 }
 
 body {
-  font-family: "Inter", "Segoe UI", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   margin: 0;
   background: url('EE Wallpaper.jpg') center/cover fixed no-repeat;
   color: var(--light-text);
@@ -29,7 +29,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Inter", "Segoe UI", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-weight: 600;
   line-height: 1.25;
   margin: 0 0 1rem;


### PR DESCRIPTION
## Summary
- remove Inter font import
- use the system font stack for body and heading styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687454f112f0832ab595026531bd7083