### PR TITLE
Restore top horizontal navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,7 +27,6 @@ html {
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   margin: 0;
-  margin-left: 200px;
   background: url('EE Wallpaper.jpg') center/cover fixed no-repeat;
   color: var(--light-text);
   line-height: 1.6;
@@ -152,16 +151,14 @@ header p {
 
 /* Navigation bar */
 nav {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  height: 100vh;
-  width: 200px;
-  padding: 2rem 1rem;
+  width: 100%;
+  padding: 0.75rem 0;
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   z-index: 998;
-  box-shadow: 2px 0 6px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(6px);
   background-color: rgba(27, 31, 36, 0.75);
 }
@@ -173,17 +170,17 @@ nav.hidden {
 nav a {
   color: var(--light-bg);
   text-decoration: none;
-  margin: 0.5rem 0;
+  margin: 0 1rem;
   padding: 0.5rem 0;
   font-weight: 500;
-  width: 100%;
-  display: block;
+  width: auto;
+  display: inline-block;
   transition: color 0.3s, transform 0.3s;
 }
 
 nav a:hover {
   color: var(--accent);
-  transform: translateX(5px);
+  transform: translateY(-2px);
 }
 
 


### PR DESCRIPTION
## Summary
- Remove sidebar layout by dropping body left margin
- Convert navigation bar to top horizontal style with centered links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a38d191898832a823df8a34e968465