### PR TITLE
Add placeholders for STM32 Bluetooth project images

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,8 @@
   <div class="card">
     <h3>Bluetooth STM32 Developer Board (In Progress)</h3>
     <p>I’m designing a custom Bluetooth-enabled STM32 development board as both a learning platform and a foundation for future embedded systems projects. Motivated by a mix of academic growth and personal interest in UAVs and IoT, this project strengthens my skills in PCB design, firmware engineering, and wireless communications. Using KiCAD 9.0 for schematic capture and PCB layout, along with STM32CubeMX/IDE and HAL libraries for microcontroller configuration and firmware development, I’m building a modular board that integrates Bluetooth connectivity, multiple I/O interfaces, and robust power regulation. The result is a functional, open-source dev board that supports rapid prototyping, experimentation, and real-world system integration.</p>
+    <img src="assets/images/STM32_BT_3D_PCB.png" alt="STM32 BT 3D PCB">
+    <img src="assets/images/STM32_BT_Schematic.png" alt="STM32 BT Schematic">
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Add placeholder image tags for STM32 Bluetooth project: 3D PCB and schematic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa9d3b83d0832aa9afe97197896960