### PR TITLE
Resize STM32 project images to fit page

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,8 +95,8 @@
   <div class="card">
     <h3>STM32 Bluetooth Developer Board (Complete)</h3>
     <p>I designed a custom Bluetooth-enabled STM32 development board as both a learning platform and a foundation for future embedded systems projects. Motivated by a mix of academic growth and personal interest in UAVs and IoT, the project strengthened my skills in PCB design, firmware engineering, and wireless communications. Using KiCAD 9.0 for schematic capture and PCB layout, along with STM32CubeMX/IDE and HAL libraries for microcontroller configuration and firmware development, I built a modular board that integrated Bluetooth connectivity, multiple I/O interfaces, and robust power regulation. The result was a functional, open-source dev board that supported rapid prototyping, experimentation, and real-world system integration.</p>
-    <img src="STM32 BT 3D PCB.png" alt="STM32 BT 3D PCB" class="floater" loading="lazy" >
-    <img src="STM32 BT Schematic.png" alt="STM32 BT Schematic" class="floater" loading="lazy" >
+    <img src="STM32 BT 3D PCB.png" alt="STM32 BT 3D PCB" class="floater project-image" loading="lazy" >
+    <img src="STM32 BT Schematic.png" alt="STM32 BT Schematic" class="floater project-image" loading="lazy" >
   </div>
 
   <div class="card">

--- a/style.css
+++ b/style.css
@@ -291,6 +291,14 @@ a.button:hover {
   animation: float 6s ease-in-out infinite;
 }
 
+.project-image {
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+  display: block;
+  margin: 1rem auto;
+}
+
 @keyframes float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-8px); }


### PR DESCRIPTION
## Summary
- limit width of STM32 project images so they fit within the page layout
- apply new `project-image` CSS class to STM32 board and schematic images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa16f7510832a96423acf2ae48060