### PR TITLE
Resize STM32 project images to fit page

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,8 +95,10 @@
   <div class="card">
     <h3>STM32 Bluetooth Developer Board (Complete)</h3>
     <p>I designed a custom Bluetooth-enabled STM32 development board as both a learning platform and a foundation for future embedded systems projects. Motivated by a mix of academic growth and personal interest in UAVs and IoT, the project strengthened my skills in PCB design, firmware engineering, and wireless communications. Using KiCAD 9.0 for schematic capture and PCB layout, along with STM32CubeMX/IDE and HAL libraries for microcontroller configuration and firmware development, I built a modular board that integrated Bluetooth connectivity, multiple I/O interfaces, and robust power regulation. The result was a functional, open-source dev board that supported rapid prototyping, experimentation, and real-world system integration.</p>
-    <img src="STM32 BT 3D PCB.png" alt="STM32 BT 3D PCB" class="floater" loading="lazy" >
-    <img src="STM32 BT Schematic.png" alt="STM32 BT Schematic" class="floater" loading="lazy" >
+    <div class="project-collage">
+      <img src="STM32 BT 3D PCB.png" alt="STM32 BT 3D PCB" class="floater" loading="lazy" />
+      <img src="STM32 BT Schematic.png" alt="STM32 BT Schematic" class="floater" loading="lazy" />
+    </div>
   </div>
 
   <div class="card">

--- a/style.css
+++ b/style.css
@@ -291,6 +291,18 @@ a.button:hover {
   animation: float 6s ease-in-out infinite;
 }
 
+.project-collage {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin: 1rem 0;
+}
+
+.project-collage img {
+  width: 50%;
+  height: auto;
+}
+
 @keyframes float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-8px); }


### PR DESCRIPTION
## Summary
- wrap STM32 board and schematic images in a flex container so they display side by side
- add `project-collage` styles to arrange images in a 2x1 collage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa16f7510832a96423acf2ae48060