### PR TITLE
Fix CSS typo breaking timeline layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -301,7 +301,7 @@ a.button:hover {
 .project-collage img {
   width: 50%;
   height: auto;
-
+}
 .project-image {
   width: 100%;
   max-width: 600px;


### PR DESCRIPTION
## Summary
- Close a missing brace in `style.css` so timeline styles parse correctly and render again.

## Testing
- `npx --yes stylelint style.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa906f144832a9a6c6417084dd465