### PR TITLE
Add image collage for Caladrius Project

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,10 +87,18 @@
 <section id="projects" class="card" data-aos="fade-up">
   <h2>Projects</h2>
 
-  <div class="card">
-    <h3>The Caladrius Project (Complete)</h3>
-    <p>Project Caladrius (HAVOC-03) was a long-endurance fixed-wing UAV developed over a 10-week rapid RDT&E cycle. Working with a 25-member interdisciplinary team, I led efforts in CAD modeling, FEA simulation, embedded system development, and machine learning integration to design, validate, and deploy the platform. The project showcased a balance of engineering depth and system-level execution, from structural and aerodynamic analysis to onboard avionics and autonomy development. Caladrius ultimately delivered a modular, flight-ready UAV that advanced endurance, adaptability, and the use of intelligent systems in real-world applications.</p>
-  </div>
+    <div class="card">
+      <h3>The Caladrius Project (Complete)</h3>
+      <p>Project Caladrius (HAVOC-03) was a long-endurance fixed-wing UAV developed over a 10-week rapid RDT&E cycle. Working with a 25-member interdisciplinary team, I led efforts in CAD modeling, FEA simulation, embedded system development, and machine learning integration to design, validate, and deploy the platform. The project showcased a balance of engineering depth and system-level execution, from structural and aerodynamic analysis to onboard avionics and autonomy development. Caladrius ultimately delivered a modular, flight-ready UAV that advanced endurance, adaptability, and the use of intelligent systems in real-world applications.</p>
+      <div class="project-collage-grid">
+        <img src="TCP Image 1.jpg" alt="Caladrius image 1" class="floater" loading="lazy" />
+        <img src="TCP Image 2.PNG" alt="Caladrius image 2" class="floater" loading="lazy" />
+        <img src="TCP Image 3.JPG" alt="Caladrius image 3" class="floater" loading="lazy" />
+        <img src="TCP Image 4.jpg" alt="Caladrius image 4" class="floater" loading="lazy" />
+        <img src="TCP Image 5.jpg" alt="Caladrius image 5" class="floater" loading="lazy" />
+        <img src="TCP Image 6.jpg" alt="Caladrius image 6" class="floater" loading="lazy" />
+      </div>
+    </div>
 
   <div class="card">
     <h3>STM32 Bluetooth Developer Board (Complete)</h3>

--- a/style.css
+++ b/style.css
@@ -310,6 +310,21 @@ a.button:hover {
   margin: 1rem auto;
 }
 
+.project-collage-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 900px;
+  margin: 1rem auto;
+}
+
+.project-collage-grid img {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
 @keyframes float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-8px); }


### PR DESCRIPTION
## Summary
- Display a 2x3 image collage in the Caladrius Project card
- Add CSS grid styles for project collages
- Adjust collage sizing to naturally fit the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aab723778c832ab3e266b788e35346