### PR TITLE
Fix Caladrius project collage layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,28 +84,29 @@
 </section>
 
 <!-- Projects showcase -->
-<section id="projects" class="card" data-aos="fade-up">
-  <h2>Projects</h2>
+  <section id="projects" data-aos="fade-up">
+    <h2>Projects</h2>
 
-    <div class="card">
+    <article class="card project-card">
       <h3>The Caladrius Project (Complete)</h3>
       <p>Project Caladrius (HAVOC-03) was a long-endurance fixed-wing UAV developed over a 10-week rapid RDT&E cycle. Working with a 25-member interdisciplinary team, I led efforts in CAD modeling, FEA simulation, embedded system development, and machine learning integration to design, validate, and deploy the platform. The project showcased a balance of engineering depth and system-level execution, from structural and aerodynamic analysis to onboard avionics and autonomy development. Caladrius ultimately delivered a modular, flight-ready UAV that advanced endurance, adaptability, and the use of intelligent systems in real-world applications.</p>
       <div class="project-collage-grid">
-        <img src="TCP Image 1.jpg" alt="Caladrius image 1" class="floater" loading="lazy" />
-        <img src="TCP Image 2.PNG" alt="Caladrius image 2" class="floater" loading="lazy" />
-        <img src="TCP Image 3.JPG" alt="Caladrius image 3" class="floater" loading="lazy" />
-        <img src="TCP Image 4.jpg" alt="Caladrius image 4" class="floater" loading="lazy" />
-        <img src="TCP Image 5.jpg" alt="Caladrius image 5" class="floater" loading="lazy" />
-        <img src="TCP Image 6.jpg" alt="Caladrius image 6" class="floater" loading="lazy" />
+        <img src="TCP Image 1.jpg" alt="Caladrius image 1" loading="lazy" />
+        <img src="TCP Image 2.PNG" alt="Caladrius image 2" loading="lazy" />
+        <img src="TCP Image 3.JPG" alt="Caladrius image 3" loading="lazy" />
+        <img src="TCP Image 4.jpg" alt="Caladrius image 4" loading="lazy" />
+        <img src="TCP Image 5.jpg" alt="Caladrius image 5" loading="lazy" />
+        <img src="TCP Image 6.jpg" alt="Caladrius image 6" loading="lazy" />
       </div>
-    </div>
+    </article>
 
   <div class="card">
     <h3>STM32 Bluetooth Developer Board (Complete)</h3>
     <p>I designed a custom Bluetooth-enabled STM32 development board as both a learning platform and a foundation for future embedded systems projects. Motivated by a mix of academic growth and personal interest in UAVs and IoT, the project strengthened my skills in PCB design, firmware engineering, and wireless communications. Using KiCAD 9.0 for schematic capture and PCB layout, along with STM32CubeMX/IDE and HAL libraries for microcontroller configuration and firmware development, I built a modular board that integrated Bluetooth connectivity, multiple I/O interfaces, and robust power regulation. The result was a functional, open-source dev board that supported rapid prototyping, experimentation, and real-world system integration.</p>
     <div class="project-collage">
-    <img src="STM32 BT 3D PCB.png" alt="STM32 BT 3D PCB" class="floater project-image" loading="lazy" >
-    <img src="STM32 BT Schematic.png" alt="STM32 BT Schematic" class="floater project-image" loading="lazy" >
+      <img src="STM32 BT 3D PCB.png" alt="STM32 BT 3D PCB" class="floater project-image" loading="lazy" />
+      <img src="STM32 BT Schematic.png" alt="STM32 BT Schematic" class="floater project-image" loading="lazy" />
+    </div>
   </div>
 
   <div class="card">

--- a/style.css
+++ b/style.css
@@ -312,14 +312,15 @@ a.button:hover {
 
 .project-collage-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 0.5rem;
+  width: 100%;
 }
 
 .project-collage-grid img {
   width: 100%;
-  height: auto;
-  height: 150px;
+  height: 100%;
+  aspect-ratio: 4 / 3;
   object-fit: cover;
   border-radius: 6px;
 }


### PR DESCRIPTION
## Summary
- restructure Caladrius project card markup for better semantics
- make project collage grid responsive so images fill the card width

## Testing
- `npx --yes prettier -c index.html style.css` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab9a1c964832abe20a162fd88f90b