### PR TITLE
Reorder Featured Projects and replace ESP32 card with BQ25570

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,22 +62,22 @@
         </article>
 
         <article class="project-preview">
-          <img src="STM32 BT 3D PCB.png" alt="ESP32 RF module PCB render" loading="lazy" />
+          <img src="TCP Image 4.jpg" alt="Power protection board development image" loading="lazy" />
           <div class="project-preview-content">
-            <h3>Stackable ESP32 RF Communication Module</h3>
-            <p class="value-line">Designed a stackable RF control board that added wireless control and board-to-board communication to an ESC platform.</p>
-            <p class="tools-line">KiCad, ESP32, Arduino IDE</p>
-            <a class="text-link" href="projects/esp32-rf-module.html">View Project →</a>
+            <h3>DRV Power Protection &amp; Monitoring PCB</h3>
+            <p class="value-line">Engineered an inline 4-layer board that removed protection and sensing bottlenecks during high-current DRV bring-up.</p>
+            <p class="tools-line">KiCad, Bench Validation, 4-Layer PCB Layout</p>
+            <a class="text-link" href="projects/drv-power-protection.html">View Project →</a>
           </div>
         </article>
 
         <article class="project-preview">
-          <img src="STM32 BT Schematic.png" alt="DRV power board schematic" loading="lazy" />
+          <img src="TCP Image 5.jpg" alt="Energy harvesting hardware image" loading="lazy" />
           <div class="project-preview-content">
-            <h3>DRV Power Protection &amp; Monitoring PCB</h3>
-            <p class="value-line">Engineered a 4-layer inline protection board to improve 8S motor-control bring-up speed, sensing visibility, and debug repeatability.</p>
-            <p class="tools-line">KiCad, 4-Layer PCB Layout, Bench Validation</p>
-            <a class="text-link" href="projects/drv-power-protection.html">View Project →</a>
+            <h3>BQ25570 Pendulum Energy Harvester PCB</h3>
+            <p class="value-line">Developed a configurable energy-harvesting PCB that converted intermittent multi-coil AC input into usable storage and output pathways.</p>
+            <p class="tools-line">KiCad, LTspice, BQ25570</p>
+            <a class="text-link" href="projects/bq25570-harvester.html">View Project →</a>
           </div>
         </article>
       </div>


### PR DESCRIPTION
### Motivation
- Reorder the Featured Projects to the exact requested sequence and remove the ESP32 card while preserving the existing layout and visual treatment.
- Surface the DRV power board and the BQ25570 energy-harvester as featured items using their existing site content.
- Make the minimal change set confined to the Featured Projects content and avoid any edits to other sections.

### Description
- Updated only the `#featured-projects` block in `index.html` to reflect the new three-card order and content.
- Replaced the second featured card with the DRV Power Protection & Monitoring PCB using the same card structure, image `TCP Image 4.jpg`, value/tools lines, and link `projects/drv-power-protection.html`.
- Replaced the third featured card with the BQ25570 Pendulum Energy Harvester PCB using the site’s existing title/summary/tools, image `TCP Image 5.jpg`, and link `projects/bq25570-harvester.html`.
- Kept the first featured card (The Caladrius Project), the Featured Projects heading/intro, CTA/link styling, and the entire `All Projects` section unchanged.

### Testing
- The patch application succeeded (`apply_patch` returned Success) and only `index.html` was modified.
- Verified the updated markup and ordering by printing excerpts of `index.html` with `sed` and `nl`, confirming the featured cards now appear in the requested order.
- Reviewed the diff to confirm only the Featured Projects content changed (10 insertions, 10 deletions) and no other sections were altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31c455628832aa1bd5ac9f7221978)